### PR TITLE
Preliminary changes to add return by date to loan command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '11'
 
+    implementation 'org.ocpsoft.prettytime:prettytime-nlp:5.0.4.Final'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,4 +16,4 @@ title: BookFace Level-3
 
 **Acknowledgements**
 
-* Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5)
+* Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5), [prettytime](https://github.com/ocpsoft/prettytime)

--- a/src/main/java/bookface/commons/core/Messages.java
+++ b/src/main/java/bookface/commons/core/Messages.java
@@ -10,4 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_BOOK_DISPLAYED_INDEX = "The book index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_BOOKS_LISTED_OVERVIEW = "%1$d books listed!";
+
+    public static final String MESSAGE_INVALID_DATE_PARSE = "Unable to parse as date.";
 }

--- a/src/main/java/bookface/logic/commands/LoanCommand.java
+++ b/src/main/java/bookface/logic/commands/LoanCommand.java
@@ -2,7 +2,9 @@ package bookface.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import bookface.commons.core.Messages;
 import bookface.commons.core.index.Index;
@@ -32,13 +34,26 @@ public class LoanCommand extends Command {
 
     private final Index targetBookIndex;
 
+    private final Date returnDate;
+
 
     /**
-     * Creates an LoanCommand to loan to a specified {@code Person} from the specified {@code Book}
+     * Creates an LoanCommand to loan to a specified {@code Person} from the specified {@code Book} with the specified
+     * return date {@code returnDate}.
      */
+    public LoanCommand(Index userIndex, Index bookIndex, Date returnDate) {
+        this.targetUserIndex = userIndex;
+        this.targetBookIndex = bookIndex;
+        this.returnDate = returnDate;
+    }
+
     public LoanCommand(Index userIndex, Index bookIndex) {
         this.targetUserIndex = userIndex;
         this.targetBookIndex = bookIndex;
+        long millis = System.currentTimeMillis();
+        Date todayDate = new Date(millis);
+        // Code below is effectively borrowed from https://stackoverflow.com/questions/12087419/adding-days-to-a-date-in-java
+        this.returnDate = new Date(todayDate.getTime() + TimeUnit.DAYS.toMillis(14));
     }
 
     @Override
@@ -62,8 +77,7 @@ public class LoanCommand extends Command {
         if (bookToLoan.isLoaned()) {
             throw new CommandException(ALREADY_LOANED);
         }
-
-        model.loan(personToLoan, bookToLoan);
+        model.loan(personToLoan, bookToLoan, returnDate);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         model.updateFilteredBookList(Model.PREDICATE_SHOW_ALL_BOOKS);
         return new CommandResult(String.format(MESSAGE_LOAN_SUCCESS, personToLoan.getName(), bookToLoan.getTitle()));

--- a/src/main/java/bookface/logic/parser/LoanCommandParser.java
+++ b/src/main/java/bookface/logic/parser/LoanCommandParser.java
@@ -1,5 +1,10 @@
 package bookface.logic.parser;
 
+import java.util.Date;
+import java.util.List;
+
+import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
+
 import bookface.commons.core.Messages;
 import bookface.commons.core.index.Index;
 import bookface.logic.commands.LoanCommand;
@@ -11,7 +16,7 @@ import bookface.logic.parser.exceptions.ParseException;
 public class LoanCommandParser implements Parser<LoanCommand> {
 
     //TODO Check if there's a better way to detect invalid loan commands
-    public static final String VALIDATION_REGEX = "(\\d+\\s+\\d+)";
+    public static final String VALIDATION_REGEX = "(\\d+\\s+\\d+\\s+(?s).*)|(\\d+\\s+\\d+)";
 
     /**
      * Parses the given {@code String} of arguments in the context of the LoanCommand
@@ -21,6 +26,7 @@ public class LoanCommandParser implements Parser<LoanCommand> {
     @Override
     public LoanCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
+        System.out.println(trimmedArgs);
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, LoanCommand.MESSAGE_USAGE));
@@ -33,16 +39,48 @@ public class LoanCommandParser implements Parser<LoanCommand> {
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
+        try {
+            String firstIndex = nameKeywords[0];
+            String secondIndex = nameKeywords[1];
+            Index userIndex = ParserUtil.parseIndex(firstIndex);
+            Index bookIndex = ParserUtil.parseIndex(secondIndex);
+
+            if (nameKeywords.length < 3) {
+                return new LoanCommand(userIndex, bookIndex);
+            }
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, LoanCommand.MESSAGE_USAGE), pe);
+        }
 
         try {
             String firstIndex = nameKeywords[0];
             String secondIndex = nameKeywords[1];
             Index userIndex = ParserUtil.parseIndex(firstIndex);
             Index bookIndex = ParserUtil.parseIndex(secondIndex);
-            return new LoanCommand(userIndex, bookIndex);
+            if (nameKeywords.length == 3) {
+                String returnDate = nameKeywords[2];
+                List<Date> parsedReturnDate = new PrettyTimeParser().parse(returnDate);
+                if (parsedReturnDate.isEmpty()) {
+                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_DATE_PARSE));
+                }
+                return new LoanCommand(userIndex, bookIndex, parsedReturnDate.get(0));
+            } else {
+                StringBuilder stringbuilder = new StringBuilder();
+                for (int i = 2; i < nameKeywords.length; i++) {
+                    stringbuilder.append(nameKeywords[i]);
+                    stringbuilder.append(" ");
+                    System.out.println(stringbuilder);
+                }
+                String parsedString = stringbuilder.toString().trim();
+                List<Date> parsedReturnDate = new PrettyTimeParser().parse(parsedString);
+                if (parsedReturnDate.isEmpty()) {
+                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_DATE_PARSE));
+                }
+                return new LoanCommand(userIndex, bookIndex, parsedReturnDate.get(0));
+            }
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, LoanCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_DATE_PARSE));
         }
     }
 }

--- a/src/main/java/bookface/model/BookFace.java
+++ b/src/main/java/bookface/model/BookFace.java
@@ -2,6 +2,7 @@ package bookface.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Date;
 import java.util.List;
 
 import bookface.commons.util.CollectionUtil;
@@ -135,13 +136,13 @@ public class BookFace implements ReadOnlyBookFace {
      * Loans to the person {@code person} in the user list with the book {@code book} in the book list.
      * {@code person} and {@code book} must exist in BookFace.
      */
-    public void loan(Person person, Book book) {
-        CollectionUtil.requireAllNonNull(person, book);
+    public void loan(Person person, Book book, Date returnDate) {
+        CollectionUtil.requireAllNonNull(person, book, returnDate);
         if (book.isLoaned()) {
             return;
         }
-        books.loan(person, book);
-        persons.loan(person, book);
+        books.loan(person, book, returnDate);
+        persons.loan(person, book, returnDate);
     }
 
     /**
@@ -165,6 +166,7 @@ public class BookFace implements ReadOnlyBookFace {
         persons.remove(key);
         books.refreshBookListAfterDeletingUser(key);
     }
+
 
     //// util methods
 

--- a/src/main/java/bookface/model/Model.java
+++ b/src/main/java/bookface/model/Model.java
@@ -1,6 +1,7 @@
 package bookface.model;
 
 import java.nio.file.Path;
+import java.util.Date;
 import java.util.function.Predicate;
 
 import bookface.commons.core.GuiSettings;
@@ -92,7 +93,7 @@ public interface Model {
      * Loans to given person {@code person} from {@code book}.
      * {@code person} and {@code book} must exist in BookFace.
      */
-    void loan(Person person, Book book);
+    void loan(Person person, Book book, Date returnDate);
 
     /**
      * Returns the {@code book} loan.

--- a/src/main/java/bookface/model/ModelManager.java
+++ b/src/main/java/bookface/model/ModelManager.java
@@ -3,6 +3,7 @@ package bookface.model;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.Date;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -131,9 +132,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void loan(Person person, Book book) {
-        CollectionUtil.requireAllNonNull(person, book);
-        bookFace.loan(person, book);
+    public void loan(Person person, Book book, Date returnDate) {
+        CollectionUtil.requireAllNonNull(person, book, returnDate);
+        bookFace.loan(person, book, returnDate);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         updateFilteredBookList(PREDICATE_SHOW_ALL_BOOKS);
     }
@@ -175,7 +176,6 @@ public class ModelManager implements Model {
         requireNonNull(predicate);
         filteredBooks.setPredicate(predicate);
     }
-
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object

--- a/src/main/java/bookface/model/book/Book.java
+++ b/src/main/java/bookface/model/book/Book.java
@@ -1,5 +1,8 @@
 package bookface.model.book;
 
+import java.text.Format;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Objects;
 
 import bookface.commons.util.CollectionUtil;
@@ -15,6 +18,8 @@ public class Book {
     private final Author author;
     private Person loanee = null;
 
+    private Date returnDate = null;
+
     /**
      * Every field must be present and not null.
      */
@@ -24,6 +29,13 @@ public class Book {
         this.author = author;
     }
 
+    public Book(Title title, Author author, Date returnDate) {
+        CollectionUtil.requireAllNonNull(title, author);
+        this.title = title;
+        this.author = author;
+        this.returnDate = returnDate;
+    }
+
     public Title getTitle() {
         return title;
     }
@@ -31,6 +43,22 @@ public class Book {
     public Author getAuthor() {
         return author;
     }
+
+    public Date getReturnDate() {
+        return returnDate;
+    }
+
+    public void setReturnDate(Date returnDate) {
+        this.returnDate = returnDate;
+    }
+    public String getReturnDateString() {
+        if (isLoaned()) {
+            Format formatter = new SimpleDateFormat("yyyy-MM-dd");
+            return "Return by: " + formatter.format(returnDate);
+        }
+        return null;
+    }
+
 
     public Person getLoanee() {
         return loanee;
@@ -53,9 +81,13 @@ public class Book {
      *
      * @param loanee the person borrowing this book
      */
-    public void loanTo(Person loanee) {
+    public void loanTo(Person loanee, Date returnDate) {
         this.loanee = loanee;
+        if (this.returnDate == null) {
+            this.returnDate = returnDate;
+        }
     }
+
 
     /**
      * Return this loaned book .

--- a/src/main/java/bookface/model/book/BookList.java
+++ b/src/main/java/bookface/model/book/BookList.java
@@ -2,6 +2,7 @@ package bookface.model.book;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -67,6 +68,7 @@ public class BookList implements Iterable<Book> {
         }
     }
 
+
     public void setBooks(BookList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
@@ -123,11 +125,11 @@ public class BookList implements Iterable<Book> {
     }
 
     /**
-     * Loans to a person {@code person} a book {@code book} .
+     * Loans to a person {@code person} a book {@code book} with the given {@code returnDate}.
      */
-    public void loan(Person person, Book book) {
-        CollectionUtil.requireAllNonNull(person, book);
-        book.loanTo(person);
+    public void loan(Person person, Book book, Date returnDate) {
+        CollectionUtil.requireAllNonNull(person, book, returnDate);
+        book.loanTo(person, returnDate);
         int index = internalList.indexOf(book);
         internalList.set(index, book);
     }

--- a/src/main/java/bookface/model/person/Person.java
+++ b/src/main/java/bookface/model/person/Person.java
@@ -1,6 +1,7 @@
 package bookface.model.person;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -60,7 +61,8 @@ public class Person {
         return loanedBooks.toString();
     }
 
-    public void addLoanedBook(Book book) {
+    public void addLoanedBook(Book book, Date returnDate) {
+        book.setReturnDate(returnDate);
         loanedBooks.add(book);
     }
 

--- a/src/main/java/bookface/model/person/UniquePersonList.java
+++ b/src/main/java/bookface/model/person/UniquePersonList.java
@@ -2,6 +2,7 @@ package bookface.model.person;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -142,9 +143,9 @@ public class UniquePersonList implements Iterable<Person> {
     /**
      * Loans to a person {@code person} a book {@code book} .
      */
-    public void loan(Person person, Book book) {
-        CollectionUtil.requireAllNonNull(person, book);
-        person.addLoanedBook(book);
+    public void loan(Person person, Book book, Date returnDate) {
+        CollectionUtil.requireAllNonNull(person, book, returnDate);
+        person.addLoanedBook(book, returnDate);
         int index = internalList.indexOf(person);
         internalList.set(index, person);
     }

--- a/src/main/java/bookface/storage/JsonAdaptedBook.java
+++ b/src/main/java/bookface/storage/JsonAdaptedBook.java
@@ -1,9 +1,13 @@
 package bookface.storage;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import bookface.commons.exceptions.IllegalValueException;
+import bookface.logic.parser.exceptions.ParseException;
 import bookface.model.book.Author;
 import bookface.model.book.Book;
 import bookface.model.book.Title;
@@ -18,13 +22,16 @@ class JsonAdaptedBook {
     private final String title;
     private final String author;
 
+    private final String returnDate;
+
     /**
      * Constructs a {@code JsonAdaptedBook} with the given book details.
      */
     @JsonCreator
-    public JsonAdaptedBook(@JsonProperty("title") String title, @JsonProperty("author") String author) {
+    public JsonAdaptedBook(@JsonProperty("title") String title, @JsonProperty("author") String author, @JsonProperty("returnDate") String returnDate) {
         this.title = title;
         this.author = author;
+        this.returnDate = returnDate;
     }
 
     /**
@@ -33,6 +40,8 @@ class JsonAdaptedBook {
     public JsonAdaptedBook(Book source) {
         title = source.getTitle().bookTitle;
         author = source.getAuthor().bookAuthor;
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        returnDate = formatter.format(source.getReturnDate());
     }
 
     /**
@@ -57,7 +66,12 @@ class JsonAdaptedBook {
         }
         final Author modelAuthor = new Author(author);
 
-        return new Book(modelTitle, modelAuthor);
+        try {
+            final Date modelDate = new SimpleDateFormat("yyyy-MM-dd").parse(returnDate);
+            return new Book(modelTitle, modelAuthor, modelDate);
+        } catch (java.text.ParseException pe) {
+            throw new ParseException(String.valueOf(pe));
+        }
     }
 }
 

--- a/src/main/java/bookface/storage/JsonSerializableBookFace.java
+++ b/src/main/java/bookface/storage/JsonSerializableBookFace.java
@@ -1,6 +1,7 @@
 package bookface.storage;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -51,7 +52,7 @@ class JsonSerializableBookFace {
     }
 
     /**
-     * Converts this address book into the model's {@code BookFace} object.
+     * Converts bookFace into the model's {@code BookFace} object.
      *
      * @throws IllegalValueException if there were any data constraints violated.
      */
@@ -66,7 +67,8 @@ class JsonSerializableBookFace {
             if (person.hasBooksOnLoan()) {
                 Set<Book> loanedBooks = person.getLoanedBooksSet();
                 for (Book book : loanedBooks) {
-                    book.loanTo(person);
+                    Date returnDate = book.getReturnDate();
+                    book.loanTo(person, returnDate);
                     bookFace.addBook(book);
                 }
             }

--- a/src/main/java/bookface/ui/BookCard.java
+++ b/src/main/java/bookface/ui/BookCard.java
@@ -33,6 +33,8 @@ public class BookCard extends UiPart<Region> {
     private Label author;
     @FXML
     private Label loanStatus;
+    @FXML
+    private Label returnBy;
 
     /**
      * Creates a {@code BookCode} with the given {@code book} and index to display.
@@ -44,6 +46,7 @@ public class BookCard extends UiPart<Region> {
         title.setText(book.getTitle().bookTitle);
         author.setText(book.getAuthor().bookAuthor);
         loanStatus.setText(book.getLoanStatus());
+        returnBy.setText(book.getReturnDateString());
     }
 
     @Override

--- a/src/main/resources/view/BookListCard.fxml
+++ b/src/main/resources/view/BookListCard.fxml
@@ -29,6 +29,7 @@
             <FlowPane fx:id="tags" />
             <Label fx:id="author" styleClass="cell_small_label" text="\$author" wrapText="true"/>
             <Label fx:id="loanStatus" styleClass="cell_small_label" text="Loan Status: \$loanstatus" wrapText="true"/>
+            <Label fx:id="returnBy" styleClass="cell_small_label" text="Return by: \$returnBy" wrapText="true"/>
         </VBox>
     </GridPane>
 </HBox>

--- a/src/test/java/bookface/logic/commands/add/AddUserCommandTest.java
+++ b/src/test/java/bookface/logic/commands/add/AddUserCommandTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -176,7 +177,7 @@ public class AddUserCommandTest {
         }
 
         @Override
-        public void loan(Person person, Book book) {
+        public void loan(Person person, Book book, Date returnDate) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
Draft, do not merge.

KNOWN ISSUES:

MAJOR ISSUE: 
Does not save books that are available after closing 
and reopening app, only saves books that are loaned out.

MODERATE ISSUE: 
After adding books, the command box no longer 
updates properly.

MINOR ISSUES:
1. Sometimes loan date does not update automatically, 
have to select it to force it to refresh.
2. Under user list, a user's loaned book list should contain the 
return by: date as well.

Resolves #151 