### PR TITLE
Fix Delete classes with respect to Loan case scenarios

### DIFF
--- a/src/main/java/bookface/commons/core/Messages.java
+++ b/src/main/java/bookface/commons/core/Messages.java
@@ -13,8 +13,8 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_BOOK = "This book is already in the records.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the records.";
     public static final String MESSAGE_INVALID_DATE_PARSE = "Unable to parse as date.";
-    public static final String MESSAGE_BOOK_STILL_ON_LOAN = "Book cannot be deleted; it is currently " +
-            "loaned out to someone!";
-    public static final String MESSAGE_PERSON_HAS_LOANS = "Person cannot be deleted; there are loans that " +
-            "are not settled!";
+    public static final String MESSAGE_BOOK_STILL_ON_LOAN = "Book cannot be deleted; it is currently "
+            + "loaned out to someone!";
+    public static final String MESSAGE_PERSON_HAS_LOANS = "Person cannot be deleted; there are loans that "
+            + "are not settled!";
 }

--- a/src/main/java/bookface/commons/core/Messages.java
+++ b/src/main/java/bookface/commons/core/Messages.java
@@ -12,6 +12,9 @@ public class Messages {
     public static final String MESSAGE_BOOKS_LISTED_OVERVIEW = "%1$d books listed!";
     public static final String MESSAGE_DUPLICATE_BOOK = "This book is already in the records.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the records.";
-
     public static final String MESSAGE_INVALID_DATE_PARSE = "Unable to parse as date.";
+    public static final String MESSAGE_BOOK_STILL_ON_LOAN = "Book cannot be deleted; it is currently " +
+            "loaned out to someone!";
+    public static final String MESSAGE_PERSON_HAS_LOANS = "Person cannot be deleted; there are loans that " +
+            "are not settled!";
 }

--- a/src/main/java/bookface/logic/commands/delete/DeleteBookCommand.java
+++ b/src/main/java/bookface/logic/commands/delete/DeleteBookCommand.java
@@ -39,6 +39,9 @@ public class DeleteBookCommand extends DeleteCommand {
         }
 
         Book bookToDelete = lastShownList.get(targetIndex.getZeroBased());
+        if (bookToDelete.isLoaned()) {
+            throw new CommandException(Messages.MESSAGE_BOOK_STILL_ON_LOAN);
+        }
         model.deleteBook(bookToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_BOOK_SUCCESS, bookToDelete));
     }

--- a/src/main/java/bookface/logic/commands/delete/DeleteUserCommand.java
+++ b/src/main/java/bookface/logic/commands/delete/DeleteUserCommand.java
@@ -38,6 +38,9 @@ public class DeleteUserCommand extends DeleteCommand {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+        if (personToDelete.hasBooksOnLoan()) {
+            throw new CommandException(Messages.MESSAGE_PERSON_HAS_LOANS);
+        }
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }

--- a/src/main/java/bookface/model/book/BookList.java
+++ b/src/main/java/bookface/model/book/BookList.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import bookface.commons.util.CollectionUtil;
 import bookface.model.book.exceptions.BookNotFoundException;
+import bookface.model.book.exceptions.BookOnLoanException;
 import bookface.model.book.exceptions.DuplicateBookException;
 import bookface.model.person.Person;
 import javafx.collections.FXCollections;
@@ -69,7 +70,7 @@ public class BookList implements Iterable<Book> {
     public void delete(Book book) {
         requireNonNull(book);
         if (book.isLoaned()) {
-            book.getLoanee().ifPresent((p) -> p.returnLoanedBook(book));
+            throw new BookOnLoanException();
         }
         if (!internalList.remove(book)) {
             throw new BookNotFoundException();

--- a/src/main/java/bookface/model/book/exceptions/BookOnLoanException.java
+++ b/src/main/java/bookface/model/book/exceptions/BookOnLoanException.java
@@ -1,0 +1,10 @@
+package bookface.model.book.exceptions;
+
+/**
+ * Signals that the operation cannot be performed since the {@code Book} is currently loaned out
+ */
+public class BookOnLoanException extends RuntimeException {
+    public BookOnLoanException() {
+        super("Book cannot be deleted; it is currently loaned out to someone!");
+    }
+}

--- a/src/main/java/bookface/model/person/UniquePersonList.java
+++ b/src/main/java/bookface/model/person/UniquePersonList.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import bookface.commons.util.CollectionUtil;
 import bookface.model.book.Book;
 import bookface.model.person.exceptions.DuplicatePersonException;
+import bookface.model.person.exceptions.PersonLoansExistException;
 import bookface.model.person.exceptions.PersonNotFoundException;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -72,13 +73,16 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Returns all books that are loaned by the user.
-     * The person must exist in the list.
+     * Removes the person from the list. The person must exist in the list.
+     * If the {@code Person} has any {@code Book} on loan, {@code Person} will
+     * not be deleted and an exception will be thrown
+     *
+     * @param toRemove Person to remove
      */
     public void remove(Person toRemove) {
         requireNonNull(toRemove);
-        for (Book book : toRemove.getLoanedBooksSet()) {
-            book.markBookAsReturned();
+        if (toRemove.hasBooksOnLoan()) {
+            throw new PersonLoansExistException();
         }
         if (!internalList.remove(toRemove)) {
             throw new PersonNotFoundException();

--- a/src/main/java/bookface/model/person/exceptions/PersonLoansExistException.java
+++ b/src/main/java/bookface/model/person/exceptions/PersonLoansExistException.java
@@ -1,0 +1,11 @@
+package bookface.model.person.exceptions;
+
+/**
+ * Signals that the operation cannot be performed since the {@code Person} still
+ * has {@code Book}s on loan
+ */
+public class PersonLoansExistException extends RuntimeException {
+    public PersonLoansExistException() {
+        super("Person cannot be deleted; there are loans that are not settled!");
+    }
+}


### PR DESCRIPTION
Fixes a potential flaw where deleting a `Person` while having a `Loan` and deleting a `Book` while it is on a `Loan` is possible.
A more reasonable behaviour should be that the `Person` or `Book` cannot be deleted if they are part of a `Loan`.

Could someone check if the new Exceptions added for this scenario are being used as intended? Custom-made exceptions are thrown, but I am not sure if they are being handled