### PR TITLE
Enhance display of books loaned by a person

### DIFF
--- a/src/main/java/bookface/model/book/Book.java
+++ b/src/main/java/bookface/model/book/Book.java
@@ -128,9 +128,9 @@ public class Book {
     @Override
     public String toString() {
         return getTitle()
-                + "; Author: "
+                + " | Author: "
                 + getAuthor()
-                + "; "
+                + " | "
                 + getReturnDateString();
     }
 }

--- a/src/main/java/bookface/ui/PersonCard.java
+++ b/src/main/java/bookface/ui/PersonCard.java
@@ -36,9 +36,10 @@ public class PersonCard extends UiPart<Region> {
     private Label phone;
     @FXML
     private Label email;
-
     @FXML
     private Label loanBook;
+    @FXML
+    private FlowPane books;
     @FXML
     private FlowPane tags;
 
@@ -52,7 +53,9 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         email.setText(person.getEmail().value);
-        loanBook.setText("Books Loaned: \n" + person.getLoanedBooksDisplayString());
+        loanBook.setText("Books Loaned: ");
+        person.getLoanedBooksSet().stream()
+                .forEach(book -> books.getChildren().add(new Label(book.getTitle().bookTitle)));
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/bookface/ui/PersonCard.java
+++ b/src/main/java/bookface/ui/PersonCard.java
@@ -37,8 +37,6 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
-    private Label loanBook;
-    @FXML
     private FlowPane books;
     @FXML
     private FlowPane tags;
@@ -53,9 +51,8 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         email.setText(person.getEmail().value);
-        loanBook.setText("Books Loaned: ");
         person.getLoanedBooksSet().stream()
-                .forEach(book -> books.getChildren().add(new Label(book.getTitle().bookTitle)));
+                .forEach(book -> books.getChildren().add(new Label(book.toString())));
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -363,3 +363,17 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+#books {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#books .label{
+    -fx-text-fill: white;
+    -fx-background-color: #e47200;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,7 +29,6 @@
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true"/>
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>
-      <Label fx:id="loanBook" styleClass="cell_small_label" text="\$loanBook" wrapText="true"/>
       <FlowPane fx:id="books" />
 
     </VBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -30,6 +30,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true"/>
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>
       <Label fx:id="loanBook" styleClass="cell_small_label" text="\$loanBook" wrapText="true"/>
+      <FlowPane fx:id="books" />
 
     </VBox>
   </GridPane>


### PR DESCRIPTION
Resolves #149 
The displaying of loaned books for each person is enhanced to match the design of tags, instead of just displaying a long string of the book details.

Issues: 
- Currently trying to find a way to align all the Book labels to the start of the label "Books loaned: "

Any feedback is appreciated! If the design is too glaring or does not fit well, please provide comments below.
